### PR TITLE
Duplicate province removed for Nepal palika level data 

### DIFF
--- a/Nepal/Facility/cr_NEP_01.do
+++ b/Nepal/Facility/cr_NEP_01.do
@@ -944,12 +944,6 @@ import delimited "$user/$data/Raw data/Nepal_2019_Jan-Dec_facility_pneum_qual.cs
 	replace orgunitlevel2 = orgunitlevel1 if orgunitlevel1=="1 Province 1"
 	replace orgunitlevel1 = "Nepal" if orgunitlevel1=="1 Province 1"
 
-* Fix issue with Province 5
-	order org*
-	//province 5 is divided into two - need to combine into 1 
-	
-	
-	
 	duplicates tag org*, gen(tag)
 	drop if tag 
 	// 2 duplicate facilities, reported no data


### PR DESCRIPTION
For some indicators, the name of Province 5 was different. So, the final dataset ended up with a duplicate of this province so I have dropped the duplicate.